### PR TITLE
add a test for demonstrating DebugExceptionHandler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,10 @@
     <artifactId>exception-handler</artifactId>
     <version>1.0.0-SNAPSHOT</version>
 
+    <properties>
+        <test.args></test.args>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -37,6 +41,14 @@
                 <configuration>
                     <source>1.5</source>
                     <target>1.5</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.8</version>
+                <configuration>
+                    <argLine>${test.args}</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,21 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.12</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>

--- a/src/main/java/net/openhft/exceptionhandler/WebExceptionHandler.java
+++ b/src/main/java/net/openhft/exceptionhandler/WebExceptionHandler.java
@@ -42,7 +42,7 @@ public class WebExceptionHandler implements ExceptionHandler {
                         version = parts[1];
                     }
 
-                    uri += "+" + version + "+" + t;
+                    uri += "+" + version + "+" + t.getClass().getName();
                     if (message != null)
                         uri += "+" + URIEncoder.encodeURI(message);
                 }

--- a/src/test/java/net/openhft/exceptionhandler/DebugExceptionHandlerTest.java
+++ b/src/test/java/net/openhft/exceptionhandler/DebugExceptionHandlerTest.java
@@ -1,0 +1,35 @@
+package net.openhft.exceptionhandler;
+
+import java.math.BigInteger;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+
+/**
+ * The exception will be handled by the {@link LoggerExceptionHandler} when the
+ * test is executed
+ * as<br><code>mvn test -Dtest=DebugExceptionHandlerTest</code><br>
+ * <br>
+ * The exception will be handled by the {@link GoogleExceptionHandler} when the
+ * test is executed
+ * as<br><code>mvn test -Dtest=DebugExceptionHandlerTest -Dtest.args=-Djdwp=debug</code>
+ *
+ * @author Frank Dietrich
+ */
+public class DebugExceptionHandlerTest {
+
+    @Test
+    public void test() {
+        ExceptionHandler handler = new DebugExceptionHandler(
+                LoggerExceptionHandler.INSTANCE,
+                GoogleExceptionHandler.INSTANCE);
+        try {
+            Object o = 42L;
+            BigInteger bi = (BigInteger) o;
+            assertTrue(true);
+        } catch (ClassCastException e) {
+            handler.onException(e.getMessage(), e);
+            fail(e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
I added a unit test for an easy demonstration of using the `DebugExceptionHandler`.

With a the small change in the `pom.xml` the different behavior can now be shown with following commands

```
// exception handled by LoggerExceptionHandler
mvn test -Dtest=DebugExceptionHandlerTest

// exception handled by GoogleExceptionHandler
mvn test -Dtest=DebugExceptionHandlerTest -Dtest.args=-Djdwp=debug
```
